### PR TITLE
Fix tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,8 +75,10 @@ jobs:
 
       - name: check chart override
         run: |
+          BASE=$(PWD)
+          cd cmd/chart-override-check
           for PROJECT in ${{ steps.check_change.outputs.changed_project }} ; do
-              go run ./cmd/chart-override-check/main.go -path charts/${PROJECT}/${PROJECT}
+              go run main.go -path ${BASE}/charts/${PROJECT}/${PROJECT}
           done
 
   call_e2e:


### PR DESCRIPTION
Fix https://github.com/DaoCloud/network-charts-repackage/pull/172 CICD
因为是未编译直接运行，调整运行位置。