### PR TITLE
fix spiderpool typo

### DIFF
--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/pod.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/pod.yaml
@@ -77,7 +77,7 @@ spec:
     - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_SUBNET
       value: {{ .Values.clusterDefaultPool.ipv4Subnet | quote }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_IPRANGES
-      value: {{ toJson .Values.clusterDefaultPool.ipv4IPRanges }}
+      value: {{ toJson .Values.clusterDefaultPool.ipv4IPRanges | quote }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_GATEWAY
       value: {{ .Values.clusterDefaultPool.ipv4Gateway | quote }}
     {{- if .Values.feature.enableSpiderSubnet }}
@@ -91,7 +91,7 @@ spec:
     - name: SPIDERPOOL_INIT_DEFAULT_IPV6_IPPOOL_SUBNET
       value: {{ .Values.clusterDefaultPool.ipv6Subnet | quote }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV6_IPPOOL_IPRANGES
-      value: {{ toJson .Values.clusterDefaultPool.ipv6IPRanges }}
+      value: {{ toJson .Values.clusterDefaultPool.ipv6IPRanges | quote }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV6_IPPOOL_GATEWAY
       value: {{ .Values.clusterDefaultPool.ipv6Gateway | quote }}
     {{- if .Values.feature.enableSpiderSubnet }}

--- a/charts/spiderpool/spiderpool/charts/spiderpool/templates/pod.yaml
+++ b/charts/spiderpool/spiderpool/charts/spiderpool/templates/pod.yaml
@@ -77,7 +77,7 @@ spec:
     - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_SUBNET
       value: {{ .Values.clusterDefaultPool.ipv4Subnet | quote }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_IPRANGES
-      value: {{ .Values.clusterDefaultPool.ipv4IPRanges | quote }}
+      value: {{ toJson .Values.clusterDefaultPool.ipv4IPRanges }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_GATEWAY
       value: {{ .Values.clusterDefaultPool.ipv4Gateway | quote }}
     {{- if .Values.feature.enableSpiderSubnet }}
@@ -91,7 +91,7 @@ spec:
     - name: SPIDERPOOL_INIT_DEFAULT_IPV6_IPPOOL_SUBNET
       value: {{ .Values.clusterDefaultPool.ipv6Subnet | quote }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV6_IPPOOL_IPRANGES
-      value: {{ .Values.clusterDefaultPool.ipv6IPRanges | quote }}
+      value: {{ toJson .Values.clusterDefaultPool.ipv6IPRanges }}
     - name: SPIDERPOOL_INIT_DEFAULT_IPV6_IPPOOL_GATEWAY
       value: {{ .Values.clusterDefaultPool.ipv6Gateway | quote }}
     {{- if .Values.feature.enableSpiderSubnet }}


### PR DESCRIPTION
```
# Source: spiderpool/charts/spiderpool/templates/pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: spiderpool-init
  namespace: "default"
  labels:
    app.kubernetes.io/name: spiderpool
    app.kubernetes.io/instance: test
    app.kubernetes.io/component: spiderpool-init
  annotations:
spec:
  serviceAccountName: spiderpool-init
  priorityClassName: system-node-critical
  hostNetwork: true
  dnsPolicy: ClusterFirstWithHostNet
  restartPolicy: Never
    kubernetes.io/os: linux
  containers:
  - name: spiderpool-init
    image: "ghcr.m.daocloud.io/spidernet-io/spiderpool/spiderpool-controller:v0.2.0"
    imagePullPolicy: IfNotPresent
    command:
      - spiderpool-init
    resources:
      limits:
        cpu: 200m
        memory: 256Mi
      requests:
        cpu: 100m
        memory: 128Mi
    env:
    - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_NAME
      value: "default-v4-ippool"
    - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_SUBNET
      value: "192.168.0.0/16"
    - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_IPRANGES
      value: "[\"1.1.1.0/24\" \"2.2.2.0/24\"]". # here
    - name: SPIDERPOOL_INIT_DEFAULT_IPV4_IPPOOL_GATEWAY
      value: "192.168.0.1"
    - name: SPIDERPOOL_INIT_DEFAULT_IPV4_SUBNET_NAME
      value: "default-v4-subnet"

```