### PR TITLE
Robot Upgrade: falco-event-generator chart upgrade from 0.1.1 to 0.2.0

### DIFF
--- a/charts/falco-event-generator/config
+++ b/charts/falco-event-generator/config
@@ -4,7 +4,7 @@ export USE_OPENSOURCE_CHART=false
 export REPO_URL=https://falcosecurity.github.io/charts
 export REPO_NAME=falcosecurity
 export CHART_NAME=event-generator
-export VERSION=0.1.1
+export VERSION=0.2.0
 
 # pr, issue, none
 export UPGRADE_METHOD=pr

--- a/charts/falco-event-generator/falco-event-generator/Chart.yaml
+++ b/charts/falco-event-generator/falco-event-generator/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: 0.9.0
+appVersion: 0.10.0
 description: A Helm chart used to deploy the event-generator in Kubernetes cluster.
 name: falco-event-generator
 type: application
-version: 0.1.1
+version: 0.2.0
 dependencies:
   - name: event-generator
-    version: "0.1.1"
+    version: "0.2.0"
     repository: "https://falcosecurity.github.io/charts"
 keywords:
 - monitoring

--- a/charts/falco-event-generator/falco-event-generator/charts/event-generator/CHANGELOG.md
+++ b/charts/falco-event-generator/falco-event-generator/charts/event-generator/CHANGELOG.md
@@ -4,14 +4,24 @@
 This file documents all notable changes to `event-generator` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v0.1.0
+## v0.2.0
 
-### Major Changes
+## Major Changes
 
-* Initial release of event-generator Helm Chart
+* Changing the grpc socket path from `unix:///var/run/falco/falco.soc` to `unix:///run/falco/falco.sock`. Please note that this change is potentially a breaking change if deploying the event generator alongside Falco < 0.33.0.
+
+### Minor Changes
+
+* Bump event-generator to 0.10.0
 
 ## v0.1.1
 
 ### Minor Changes
 
 * Adding `-sleep` flag to the `pod-template.yaml` 
+
+## v0.1.0
+
+### Major Changes
+
+* Initial release of event-generator Helm Chart

--- a/charts/falco-event-generator/falco-event-generator/charts/event-generator/Chart.yaml
+++ b/charts/falco-event-generator/falco-event-generator/charts/event-generator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.9.0
+appVersion: 0.10.0
 description: A Helm chart used to deploy the event-generator in Kubernetes cluster.
 name: event-generator
 type: application
-version: 0.1.1
+version: 0.2.0

--- a/charts/falco-event-generator/falco-event-generator/charts/event-generator/generated/helm-values.md
+++ b/charts/falco-event-generator/falco-event-generator/charts/event-generator/generated/helm-values.md
@@ -6,11 +6,11 @@ A Helm chart used to deploy the event-generator in Kubernetes cluster.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity, like the nodeSelector but with more expressive syntax. |
-| config.actions | string | `"^k8saudit"` | Regular expression used to select the actions to be run. |
-| config.command | string | `"test"` | The event-generator accepts two commands (run, test): run: runs actions. test: runs and tests actions. For more info see: https://github.com/falcosecurity/event-generator. |
-| config.grpc.bindAddress | string | `"unix:///var/run/falco/falco.sock"` | Path to the Falco grpc socket. |
-| config.grpc.enabled | bool | `true` | Set it to true if you are deploying in "test" mode. |
-| config.loop | bool | `false` | Runs in a loop the actions. If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job. |
+| config.actions | string | `"^syscall"` | Regular expression used to select the actions to be run. |
+| config.command | string | `"run"` | The event-generator accepts two commands (run, test): run: runs actions. test: runs and tests actions. For more info see: https://github.com/falcosecurity/event-generator. |
+| config.grpc.bindAddress | string | `"unix:///run/falco/falco.sock"` | Path to the Falco grpc socket. |
+| config.grpc.enabled | bool | `false` | Set it to true if you are deploying in "test" mode. |
+| config.loop | bool | `true` | Runs in a loop the actions. If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job. |
 | config.sleep | string | `""` | The length of time to wait before running an action. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms) |
 | fullnameOverride | string | `""` | Used to override the chart full name. |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the event-generator image |

--- a/charts/falco-event-generator/falco-event-generator/charts/event-generator/values.yaml
+++ b/charts/falco-event-generator/falco-event-generator/charts/event-generator/values.yaml
@@ -65,4 +65,4 @@ config:
     # -- Set it to true if you are deploying in "test" mode.
     enabled: false
     # -- Path to the Falco grpc socket.
-    bindAddress: "unix:///var/run/falco/falco.sock"
+    bindAddress: "unix:///run/falco/falco.sock"

--- a/charts/falco-event-generator/falco-event-generator/values.yaml
+++ b/charts/falco-event-generator/falco-event-generator/values.yaml
@@ -67,4 +67,4 @@ event-generator:
       # -- Set it to true if you are deploying in "test" mode.
       enabled: false
       # -- Path to the Falco grpc socket.
-      bindAddress: "unix:///var/run/falco/falco.sock"
+      bindAddress: "unix:///run/falco/falco.sock"


### PR DESCRIPTION
I am robot, upgrade: project falco-event-generator chart upgrade from 0.1.1 to 0.2.0